### PR TITLE
Add support for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,23 @@
 {
-  "name": "techquity/query-macros",
-  "license": "MIT",
-  "require": {
-    "php": "^7.2|^8.0",
-    "illuminate/database": "^6.20.12|^7.30.3|^8.22.1|^9.0|^10.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Techquity\\QueryMacros\\": "src/"
+    "name": "techquity/query-macros",
+    "license": "MIT",
+    "require": {
+        "php": "^7.2|^8.0",
+        "illuminate/database": "^6.20.12|^7.30.3|^8.22.1|^9.0|^10.0|^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Techquity\\QueryMacros\\": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Techquity\\QueryMacros\\ServiceProvider"
+            ]
+        }
     }
-  },
-  "extra": {
-    "laravel": {
-      "providers": [
-        "Techquity\\QueryMacros\\ServiceProvider"
-      ]
-    }
-  }
 }


### PR DESCRIPTION
- Require `illuminate/database` `^11.0` needed for Laravel 11
- Tweaked indentation
